### PR TITLE
weave version update

### DIFF
--- a/src/lib_covariances.py
+++ b/src/lib_covariances.py
@@ -8,7 +8,7 @@
 import numpy as np
 import sys, copy, os, glob
 
-from scipy.weave import inline, converters
+from weave import inline, converters
 from scipy import interpolate
 
 from loop_lensing import loop_lensing


### PR DESCRIPTION
`weave` is moved out into its separate project (See https://github.com/scipy/weave for details.) And it is no longer under scipy. 

Thanks!
DW

